### PR TITLE
Fix compilation error on GHC-9.0 due to simplified subsumption

### DIFF
--- a/src/Data/Type/Util.hs
+++ b/src/Data/Type/Util.hs
@@ -72,7 +72,7 @@ withVec
     -> (forall n. VecT n f a -> r)
     -> r
 withVec = \case
-    []   -> ($ VNil)
+    []   -> \f -> f VNil
     x:xs -> \f -> withVec xs (f . (x :*))
 {-# INLINE withVec #-}
 


### PR DESCRIPTION
GHC-9.0 failed to type-check the current implementation of `withVec`

https://github.com/mstksg/backprop/blob/e8962c2029476c7721c5f5488e8689737294ceee/src/Data/Type/Util.hs#L70-L76

with the following error:

```
[ 1 of 10] Compiling Data.Type.Util

/.../backprop/src/Data/Type/Util.hs:75:14: error:
    • Couldn't match type: VecT 'Z f0 a0 -> r
                     with: forall (n :: Nat). VecT n f a -> r
      Expected: (forall (n :: Nat). VecT n f a -> r) -> r
        Actual: (VecT 'Z f0 a0 -> r) -> r
    • In the expression: $ VNil
      In a case alternative: [] -> ($ VNil)
      In the expression:
        \case
          [] -> ($ VNil)
          x : xs -> \ f -> withVec xs (f . (x :*))
    • Relevant bindings include
        withVec :: [f a] -> (forall (n :: Nat). VecT n f a -> r) -> r
          (bound at src/Data/Type/Util.hs:74:1)
   |
75 |     []   -> ($ VNil)
   |              ^^^^^^
```

Before GHC 9.0, `($ VNil)`'s type `(VecT 'Z f0 a0 -> r) -> r` is considered more polymorphic than expected type `(forall (n :: Nat). VecT n f a -> r) -> r` because of the contravariance of functions types in the subsumption judgement.

But the [simplify subsumption](https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0287-simplify-subsumption.rst) proposal landed on GHC 9.0 removed the contravariance, and caused the type error.

This PR fixes the problem by simple eta-expansion.

