### PR TITLE
Do not use Data.Semigroup.Option type on base >=4.16.0.0 (i.e. GHC >=9.2.1)

### DIFF
--- a/src/Numeric/Backprop/Class.hs
+++ b/src/Numeric/Backprop/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns               #-}
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DataKinds                  #-}
 {-# LANGUAGE DefaultSignatures          #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
@@ -901,11 +902,13 @@ instance Backprop a => Backprop (Product a) where
     add  = coerce (add @a)
     one  = coerce (one @a)
 
+#if !MIN_VERSION_base(4,16,0)
 -- | @since 0.2.2.0
 instance Backprop a => Backprop (SG.Option a) where
     zero = coerce (zero @(Maybe a))
     add  = coerce (add @(Maybe a))
     one  = coerce (one @(Maybe a))
+#endif
 
 -- | @since 0.2.2.0
 instance Backprop a => Backprop (SG.First a) where


### PR DESCRIPTION
As @Mikolaj reported on https://github.com/mstksg/backprop/pull/19#issuecomment-1010063543 , the current `master` branch fails to compile on GHC 9.2 not only due to the simplified subsumption (#19) but also due to the removal of `Data.Semigroup.Option` on `base >=4.16.0.0`.

See also:
* https://hackage.haskell.org/package/base-4.15.0.0/docs/Data-Semigroup.html#t:Option
  > Deprecated: will be removed in GHC 9.2; use Maybe instead.
* https://hackage.haskell.org/package/base-4.16.0.0/docs/Data-Semigroup.html

This PR fixes the latter problem.

I confirmed that GHC 9.2 can compile this PR + #19 with `Vinyl` [322476778d11223ac40f1e1c3faddc007eaef72a](https://github.com/VinylRecords/Vinyl/tree/322476778d11223ac40f1e1c3faddc007eaef72a) (I did not use the `master` branch of `Vinyl` because of https://github.com/VinylRecords/Vinyl/issues/157) + https://github.com/VinylRecords/Vinyl/issues/156 fix.

