### PR TITLE
Support vinyl 0.14

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -33,6 +33,11 @@ description: |
 
     See <https://backprop.jle.im> for official introduction and documentation.
 
+flags:
+  vinyl_0_14:
+    manual: false
+    default: true
+
 ghc-options:
 - -Wall
 - -Wcompat
@@ -66,6 +71,14 @@ library:
   - reflection
   - transformers
   - vinyl >= 0.9.1
+  when:
+    - condition: flag(vinyl_0_14)
+      then:
+        dependencies:
+        - vinyl >= 0.14.2
+      else:
+        dependencies:
+        - vinyl < 0.14
 
 benchmarks:
   backprop-mnist-bench:

--- a/src/Numeric/Backprop/Class.hs
+++ b/src/Numeric/Backprop/Class.hs
@@ -983,7 +983,11 @@ instance (ReifyConstraint Backprop f rs, RMap rs, RApply rs) => Backprop (Rec f 
     {-# INLINE one #-}
 
 -- | @since 0.2.6.3
+#if MIN_VERSION_vinyl(0,14,2)
+instance (ReifyConstraint Backprop f rs, RMap rs, RApply rs, RecApplicative rs, NatToInt (RLength rs), RPureConstrained (IndexableField rs) rs, ToARec rs)
+#else
 instance (ReifyConstraint Backprop f rs, RMap rs, RApply rs, RecApplicative rs, NatToInt (RLength rs), RPureConstrained (IndexableField rs) rs)
+#endif
       => Backprop (ARec f rs) where
     zero = toARec . zero . fromARec
     {-# INLINE zero #-}


### PR DESCRIPTION
We need `ToARec` class context to use `toARec` on `vinyl >= 0.14`.

Unfortunately `vinyl-0.14.1` does not export the `ToARec` class (https://github.com/VinylRecords/Vinyl/issues/157), therefore we need to use `vinyl <0.14` or `vinyl >=0.14.2`.