### PR TITLE
Makes compiles with GHC 9.0.

### DIFF
--- a/src/Data/Type/Util.hs
+++ b/src/Data/Type/Util.hs
@@ -72,7 +72,7 @@ withVec
     -> (forall n. VecT n f a -> r)
     -> r
 withVec = \case
-    []   -> ($ VNil)
+    []   -> \f -> f VNil
     x:xs -> \f -> withVec xs (f . (x :*))
 {-# INLINE withVec #-}
 


### PR DESCRIPTION
`backprop` sufferred from shallow subsumption introduced in GHC 9.0.
This PR fixes this by eta-expanding the applicaiton of `VNil`.

Partially fixes #19; we need some tweaks around `Option` and `vinyl` to get `backprop` compiles with GHC 9.2 + Nightly.